### PR TITLE
Added ability to disable deb repo inclusion.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,3 +46,4 @@ nginx_service_name: nginx
 nginx_yum_pkg: nginx
 nginx_yum_enablerepo: no
 nginx_yum_disablerepo: no
+nginx_apt_use_repo: yes

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -5,6 +5,7 @@
 
 - name: Add nginx repository
   apt_repository: repo=ppa:nginx/stable
+  when: nginx_apt_use_repo
 
 - name: Install Dependencies
   apt: pkg={{item}}


### PR DESCRIPTION
This very simple change, symmetric to the YUM repo flags, allows you to skip the addition of the PPA.

Useful whenever your node's architecture is not supported by the PPA (e.g. ARM).