### PR TITLE
Added autodetection of whether to use PPA ("pure Debian can't) + override

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ nginx_auth_users: []                # Setup users for http authentication
                                     #   - { name: team, password: secret }
 
 nginx_status: 127.0.0.1             # Report about nginx state by IP. Set empty for disable.
+nginx_apt_use_ppa_repo: no          # Force use of nginx PPA repo, even if Ansible detects a non-compatible distro
 ```
 
 #### Usage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,4 +46,4 @@ nginx_service_name: nginx
 nginx_yum_pkg: nginx
 nginx_yum_enablerepo: nginx
 nginx_yum_disablerepo: no
-nginx_apt_use_repo: yes
+nginx_apt_use_ppa_repo: no         # Force use of nginx PPA repo, even if Ansible detects a non-compatible distro

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -7,7 +7,7 @@
 
 - name: Add nginx repository
   apt_repository: repo=ppa:nginx/stable
-  when: nginx_apt_use_repo
+  when: nginx_apt_use_ppa_repo or (ansible_distribution != "Debian")
 
 - name: Install Dependencies
   apt: pkg={{item}}


### PR DESCRIPTION
This PR modifies the logic introduced previously to autodetect Debian boxes (the one where PPAs don't work, see [e.g. this doc section](http://docs.ansible.com/ansible/apt_repository_module.html#examples) ), and at last documents the introduced flag (that is now an override).