### PR TITLE
+ allow to set log_format (switch order of log_file with http options

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -37,12 +37,12 @@ http {
 
     server_names_hash_bucket_size {{nginx_server_names_hash_bucket_size}};
 
-    access_log {{nginx_access_log}};
-    error_log {{nginx_error_log}};
-
 {% if nginx_http_options %}{% for option in nginx_http_options %}
     {{option}}
 {% endfor %}{% endif %}
+
+    access_log {{nginx_access_log}};
+    error_log {{nginx_error_log}};
 
 {% if nginx_status %}
     server {


### PR DESCRIPTION
Setting http options before access_log/error_log give ability to define log format like this:

```
    nginx_access_log: /var/log/nginx/access.log main
    nginx_http_options:
      - |
        log_format main '$http_x_forwarded_for - $remote_user [$time_local] "$host" "$request" ' 
            '$status $body_bytes_sent "$http_referer" '
            '"$http_user_agent" $request_time';
```