### PR TITLE
Added tasks to permit pushing vhost files from templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ nginx_servers:                      # Setup servers (simplest interface, use cfg
                                     #       listen 80;
                                     #       server_name test.com;
                                     #       location / { root /test; index index.html; }
-nginx_templatized_vhosts:			# Setup vhosts files (one domain name per configuration file)
-									# by specifying source template path
-									# Ex: nginx_templatized_vhosts:
-									#	    - { "name": "example.com", "template": "templates/my_vhost.j2" }
+nginx_templatized_vhosts:           # Setup vhosts files (one domain name per configuration file)
+                                    # by specifying source template path
+                                    # Ex: nginx_templatized_vhosts:
+                                    #       - { "name": "example.com", "template": "templates/my_vhost.j2" }
 
 nginx_auth_file: "{{nginx_dir}}/.htpasswd" # Where stored passwords
 nginx_auth_users: []                # Setup users for http authentication

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ nginx_servers:                      # Setup servers (simplest interface, use cfg
                                     #       listen 80;
                                     #       server_name test.com;
                                     #       location / { root /test; index index.html; }
+nginx_templatized_vhosts:			# Setup vhosts files (one domain name per configuration file)
+									# by specifying source template path
+									# Ex: nginx_templatized_vhosts:
+									#	    - { "name": "example.com", "template": "templates/my_vhost.j2" }
 
 nginx_auth_file: "{{nginx_dir}}/.htpasswd" # Where stored passwords
 nginx_auth_users: []                # Setup users for http authentication

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 Stouts.nginx
 ============
 
-[![Build Status](http://img.shields.io/travis/Stouts/Stouts.nginx.svg?style=flat-square)](https://travis-ci.org/Stouts/Stouts.nginx)
-[![Galaxy](http://img.shields.io/badge/galaxy-Stouts.nginx-blue.svg?style=flat-square)](https://galaxy.ansible.com/list#/roles/854)
+[![Build Status](http://img.shields.io/travis/bpetit/Stouts.nginx.svg?style=flat-square)](https://travis-ci.org/bpetit/Stouts.nginx)
 
 Ansible role which simple manage nginx
 
@@ -83,12 +82,16 @@ Licensed under the MIT License. See the LICENSE file for details.
 
 #### Feedback, bug-reports, requests, ...
 
-Are [welcome](https://github.com/Stouts/Stouts.nginx/issues)!
+Are [welcome](https://github.com/bpetit/Stouts.nginx/issues)!
 
 If you wish to express your appreciation for the role, you are welcome to send
-a postcard to:
+a postcard to the original author:
 
     Kirill Klenov
     pos. Severny 8-3
     MO, Istra, 143500
     Russia
+
+Or, if it is about this fork:
+
+	Benoit Petit <bpetit@b0rk.in>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 nginx_enabled: yes                  # The role in enabled
 nginx_dir: /etc/nginx               # Nginx config directory
+nginx_sites_available_dir: "{{ nginx_dir }}/sites-available"
 nginx_sites_dir: "{{nginx_dir}}/sites-enabled" # Nginx include directory
 nginx_default_site: "{{nginx_sites_dir}}/default"
 nginx_delete_default_site: no

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,11 @@
 ---
 
 - name: nginx restart
-  service: name={{nginx_service_name}} state=restarted
+  service:
+    name: "{{nginx_service_name}}"
+    state: restarted
 
 - name: nginx reload
-  service: name={{nginx_service_name}} state=reloaded
+  service:
+    name: "{{nginx_service_name}}"
+    state: reloaded

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -3,12 +3,15 @@
 - include_vars: "{{ansible_distribution}}.yml"
 
 - name: Install dependencies
-  apt: name=python-pycurl
+  apt:
+    name: python-pycurl
 
 - name: Add nginx repository
-  apt_repository: repo=ppa:nginx/stable
+  apt_repository:
+    repo: ppa:nginx/stable
   when: nginx_apt_use_ppa_repo and ansible_distribution == "Ubuntu"
 
 - name: Install Dependencies
-  apt: name={{item}}
-  with_items: [ nginx, python-passlib ] 
+  apt:
+    name: "{{ item }}"
+  with_items: [ nginx, python-passlib ]

--- a/tasks/install.red.yml
+++ b/tasks/install.red.yml
@@ -1,10 +1,16 @@
 ---
 
 - name: Ensure libselinux-python is installed
-  yum: name=libselinux-python
+  yum:
+    name: libselinux-python
 
 - name: Setup repo
-  copy: src=nginx.repo dest=/etc/yum.repos.d/nginx.repo
+  copy:
+    src: nginx.repo
+    dest: /etc/yum.repos.d/nginx.repo
 
 - name: Install Nginx
-  yum: name={{nginx_yum_pkg}} enablerepo={{nginx_yum_enablerepo or None}} disablerepo={{nginx_yum_disablerepo or None}}
+  yum:
+    name: "{{nginx_yum_pkg}}"
+    enablerepo: "{{nginx_yum_enablerepo or None}}"
+    disablerepo: "{{nginx_yum_disablerepo or None}}"

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -49,10 +49,10 @@
     state: link
     src: "{{ nginx_sites_available_dir }}/{{ item.name }}.conf"
     dest: "{{ nginx_sites_dir }}/{{ item.name }}.conf"
+    validate: nginx -t
   with_items:
     - "{{ nginx_templatized_vhosts }}"
   when: nginx_templatized_vhosts is defined
-  validate: nginx -t
 
 - name: Configure nginx
   template:

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -20,10 +20,10 @@
 
 - name: Encrypt http auth passwords
   htpasswd:
-    path: "{{nginx_auth_file}}"
-    name: "{{item.name}}"
-    password: "{{item.password}}"
-  with_items: "{{nginx_auth_users}}"
+    path: "{{ nginx_auth_file }}"
+    name: "{{ item.name }}"
+    password: "{{ item.password }}"
+  with_items: "{{ nginx_auth_users }}"
 
 - name: Ensure the sites available directory exists
   file:
@@ -41,7 +41,7 @@
 
 - name: Ensure the sites directory is exists
   file:
-    name: "{{nginx_sites_dir}}"
+    name: "{{ nginx_sites_dir }}"
     state: directory
 
 - name: Enable vhosts (from templates)
@@ -56,12 +56,12 @@
 - name: Configure nginx
   template:
     src: nginx.conf.j2
-    dest: "{{nginx_dir}}/nginx.conf"
+    dest: "{{ nginx_dir }}/nginx.conf"
   notify: nginx restart
 
 
 - name: Ensure that nginx is started
   service:
-    name: "{{nginx_service_name}}"
+    name: "{{ nginx_service_name }}"
     state: started
     enabled: yes

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -18,6 +18,26 @@
   htpasswd: path={{nginx_auth_file}} name={{item.name}} password={{item.password}}
   with_items: "{{nginx_auth_users}}"
 
+- name: Ensure the sites directory is exists
+  file:
+    name: "{{ nginx_sites_available_dir }}"
+    state: directory
+
+- name: Create vhosts from template
+  template:
+    src: "{{ item.template }}"
+    dest: "{{ nginx_sites_available_dir }}/{{ item.name }}.conf"
+  with_items:
+    - "{{ nginx_templatized_vhosts }}"
+
+- name: enable vhosts
+  file:
+    state: link
+    src: "{{ nginx_sites_available_dir }}/{{ item.name }}.conf"
+    dest: "{{ nginx_sites_dir }}/{{ item.name }}.conf"
+  with_items:
+    - "{{ nginx_templatized_vhosts }}"
+
 - name: Configure nginx
   template: src=nginx.conf.j2 dest={{nginx_dir}}/nginx.conf
   notify: nginx restart

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -52,6 +52,7 @@
   with_items:
     - "{{ nginx_templatized_vhosts }}"
   when: nginx_templatized_vhosts is defined
+  validate: nginx -t
 
 - name: Configure nginx
   template:

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -7,21 +7,29 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure that Nginx user is exist
-  user: name={{nginx_user}} system=yes
+  user:
+    name: "{{ nginx_user }}"
+    system: yes
 
 - name: Delete default site
-  action: file path={{nginx_default_site}} state=absent
+  file:
+    path: "{{ nginx_default_site }}"
+    state: absent
   when: nginx_delete_default_site
   notify: nginx restart
 
 - name: Encrypt http auth passwords
-  htpasswd: path={{nginx_auth_file}} name={{item.name}} password={{item.password}}
+  htpasswd:
+    path: "{{nginx_auth_file}}"
+    name: "{{item.name}}"
+    password: "{{item.password}}"
   with_items: "{{nginx_auth_users}}"
 
-- name: Ensure the sites directory is exists
+- name: Ensure the sites available directory exists
   file:
     name: "{{ nginx_sites_available_dir }}"
     state: directory
+  when: nginx_sites_available_dir is defined
 
 - name: Create vhosts from template
   template:
@@ -29,21 +37,31 @@
     dest: "{{ nginx_sites_available_dir }}/{{ item.name }}.conf"
   with_items:
     - "{{ nginx_templatized_vhosts }}"
+  when: nginx_templatized_vhosts is defined
 
-- name: enable vhosts
+- name: Ensure the sites directory is exists
+  file:
+    name: "{{nginx_sites_dir}}"
+    state: directory
+
+- name: Enable vhosts (from templates)
   file:
     state: link
     src: "{{ nginx_sites_available_dir }}/{{ item.name }}.conf"
     dest: "{{ nginx_sites_dir }}/{{ item.name }}.conf"
   with_items:
     - "{{ nginx_templatized_vhosts }}"
+  when: nginx_templatized_vhosts is defined
 
 - name: Configure nginx
-  template: src=nginx.conf.j2 dest={{nginx_dir}}/nginx.conf
+  template:
+    src: nginx.conf.j2
+    dest: "{{nginx_dir}}/nginx.conf"
   notify: nginx restart
 
-- name: Ensure the sites directory is exists
-  file: name={{nginx_sites_dir}} state=directory
 
 - name: Ensure that nginx is started
-  service: name={{nginx_service_name}} state=started enabled=yes
+  service:
+    name: "{{nginx_service_name}}"
+    state: started
+    enabled: yes

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -29,7 +29,7 @@ http {
     keepalive_timeout  {{nginx_keepalive_timeout}};
     keepalive_requests  {{nginx_keepalive_requests}};
 
-    client_max_body_size {{ nginx_client_max_body_size | default(2M) }};
+    client_max_body_size {{ nginx_client_max_body_size | default('2M') }};
 
 {% if nginx_gzip %}
     gzip on;

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -29,6 +29,8 @@ http {
     keepalive_timeout  {{nginx_keepalive_timeout}};
     keepalive_requests  {{nginx_keepalive_requests}};
 
+    client_max_body_size {{ nginx_client_max_body_size | default(2M) }};
+
 {% if nginx_gzip %}
     gzip on;
     gzip_disable "msie6";


### PR DESCRIPTION
Added tasks that take a list of dictionaries containing a domain name and a path to a template.
Pushes resulting files in a defined sites-available directory and creates a symlink to nginx_site_dir.

It is useful for me. Can it be for others ?

Also applied latest ansible recommended syntax.

Available to discuss about it.